### PR TITLE
Fix invalid Solr syntax when "search" parameter contains only spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,7 @@ class DataSource {
         if (request.order) params.sort = buildSolrOrderString(request.order);
 
         if (request.df) params.df = request.df;
-        if (request.search) queryParts.push(escapeValueForSolr(request.search, request.exposeSolrSyntax));
+        if (request.search && request.search.trim()) queryParts.push(escapeValueForSolr(request.search, request.exposeSolrSyntax));
         if (request.filter) {
             queryParts.push(buildSolrFilterString(request.filter));
         }

--- a/test/flora-solr.spec.js
+++ b/test/flora-solr.spec.js
@@ -400,6 +400,20 @@ describe('Flora SOLR DataSource', () => {
 
             dataSource.process(request);
         });
+
+        it.only('should ignore empty search terms', () => {
+            const request = {
+                collection: 'article',
+                search: ' ',
+                filter: [[{ attribute: 'authorId', operator: 'equal', value: 1337 }]]
+            };
+
+            req = nock(solrUrl)
+                .post(solrIndexPath, _.matches({ q: '(authorId:1337)' }))
+                .reply(200, testResponse);
+
+            dataSource.process(request);
+        });
     });
 
     describe('order', () => {


### PR DESCRIPTION
Fixes #2